### PR TITLE
Add `--discard-non-magik` option to filter coverage on non-Magik sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Changes
 
 2.2.0 (unreleased)
 
+- Add `--discard-non-magik` option to filter coverage on non-Magik sources.
+
 2.1.2 (2023-10-03)
 
 - Make `--product-path` optional. If not given, current directory is used.

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/Main.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/Main.java
@@ -56,6 +56,10 @@ public final class Main {
         .longOpt("discard-executable")
         .desc("Discard executable classes")
         .build();
+    private static final Option OPTION_DISCARD_NON_MAGIK = Option.builder()
+        .longOpt("discard-non-magik")
+        .desc("Discard non-Magik sources")
+        .build();
     private static final Option OPTION_HTML = Option.builder()
         .longOpt("html")
         .desc("Output HTML report to directory")
@@ -94,6 +98,7 @@ public final class Main {
         OPTIONS.addOption(OPTION_SOURCE_PATH);
         OPTIONS.addOption(OPTION_JACOCO_FILE);
         OPTIONS.addOption(OPTION_DISCARD_EXECUTABLE);
+        OPTIONS.addOption(OPTION_DISCARD_NON_MAGIK);
         OPTIONS.addOption(OPTION_HTML);
         OPTIONS.addOption(OPTION_JACOCO_XML);
         OPTIONS.addOption(OPTION_SONAR_XML);
@@ -161,6 +166,7 @@ public final class Main {
             : Collections.emptyList();
         final File executionDataFile = (File) commandLine.getParsedOptionValue(OPTION_JACOCO_FILE);
         final boolean discardExecutable = commandLine.hasOption(OPTION_DISCARD_EXECUTABLE);
+        final boolean discardNonMagik = commandLine.hasOption(OPTION_DISCARD_NON_MAGIK);
         final String bundleName = commandLine.hasOption(OPTION_BUNDLE_NAME)
             ? commandLine.getOptionValue(OPTION_BUNDLE_NAME)
             : DEFAULT_BUNDLE_NAME;
@@ -173,6 +179,7 @@ public final class Main {
                 executionDataFile,
                 outputDir,
                 discardExecutable,
+                discardNonMagik,
                 bundleName);
             htmlReportGenerator.run();
         } else if (commandLine.hasOption(OPTION_JACOCO_XML)) {
@@ -183,6 +190,7 @@ public final class Main {
                 executionDataFile,
                 outputFile,
                 discardExecutable,
+                discardNonMagik,
                 bundleName);
             xmlReportGenerator.run();
         } else if (commandLine.hasOption(OPTION_SONAR_XML)) {
@@ -193,6 +201,7 @@ public final class Main {
                 executionDataFile,
                 outputFile,
                 discardExecutable,
+                discardNonMagik,
                 bundleName);
             sonarXmlReportGenerator.run();
         } else if (commandLine.hasOption(OPTION_COBERTURA_XML)) {
@@ -203,6 +212,7 @@ public final class Main {
                 executionDataFile,
                 outputFile,
                 discardExecutable,
+                discardNonMagik,
                 bundleName);
             coberturaXmlReportGenerator.run();
         }

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/conversion/MagikBundleCoverageConverter.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/conversion/MagikBundleCoverageConverter.java
@@ -48,6 +48,7 @@ public class MagikBundleCoverageConverter {
     private final Sw5LibAnalyzer libAnalyzer;
     private final IBundleCoverage bundleCoverage;
     private final boolean discardExecutable;
+    private final boolean discardNonMagik;
     private final SmallworldProducts smallworldProducts;
 
     /**
@@ -55,14 +56,17 @@ public class MagikBundleCoverageConverter {
      * @param libAnalyzer Lib reader.
      * @param bundleCoverage Bundle coverage.
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      */
     public MagikBundleCoverageConverter(
             final Sw5LibAnalyzer libAnalyzer,
             final IBundleCoverage bundleCoverage,
-            final boolean discardExecutable) {
+            final boolean discardExecutable,
+            final boolean discardNonMagik) {
         this.libAnalyzer = libAnalyzer;
         this.bundleCoverage = bundleCoverage;
         this.discardExecutable = discardExecutable;
+        this.discardNonMagik = discardNonMagik;
 
         final List<Path> productPaths = this.libAnalyzer.getProductPaths();
         this.smallworldProducts = new SmallworldProducts(productPaths);
@@ -76,6 +80,7 @@ public class MagikBundleCoverageConverter {
         final String name = this.bundleCoverage.getName();
         final List<IPackageCoverage> newPackages = this.bundleCoverage.getPackages().stream()
             .map(this::convert)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
         final BundleCoverageImpl newBundleCoverage = new BundleCoverageImpl(name, newPackages);
 
@@ -87,6 +92,10 @@ public class MagikBundleCoverageConverter {
     private IPackageCoverage convert(final IPackageCoverage packageCoverage) {
         final String name = packageCoverage.getName();
         if (!name.matches("^magik/.*")) {
+            if (this.discardNonMagik) {
+                return null;
+            }
+
             return packageCoverage;
         }
 

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/BaseReportGenerator.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/BaseReportGenerator.java
@@ -33,6 +33,7 @@ public abstract class BaseReportGenerator {
     private final File outputFile;
     private final File executionDataFile;
     private final boolean discardExecutable;
+    private final boolean discardNonMagik;
     private final String bundleName;
     private final ExecFileLoader execFileLoader = new ExecFileLoader();
     private Sw5LibAnalyzer libAnalyzer;
@@ -49,6 +50,7 @@ public abstract class BaseReportGenerator {
      * @param executionDataFile File to {@literal jacoco.exec}.
      * @param outputFile File to report directory.
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      * @param bundleName Name of the bundle.
      */
     protected BaseReportGenerator(
@@ -57,12 +59,14 @@ public abstract class BaseReportGenerator {
             final File executionDataFile,
             final File outputFile,
             final boolean discardExecutable,
+            final boolean discardNonMagik,
             final String bundleName) {
         this.productPaths = productPaths;
         this.sourcePaths = sourcePaths;
         this.executionDataFile = executionDataFile;
         this.outputFile = outputFile;
         this.discardExecutable = discardExecutable;
+        this.discardNonMagik = discardNonMagik;
         this.bundleName = bundleName;
     }
 
@@ -134,8 +138,11 @@ public abstract class BaseReportGenerator {
         final IBundleCoverage bundleCoverage = coverageBuilder.getBundle(this.bundleName);
 
         // Merge method coverages (Magik), discard executable parts if needed.
-        final MagikBundleCoverageConverter bundleCoverageConverter =
-            new MagikBundleCoverageConverter(this.libAnalyzer, bundleCoverage, this.discardExecutable);
+        final MagikBundleCoverageConverter bundleCoverageConverter = new MagikBundleCoverageConverter(
+            this.libAnalyzer,
+            bundleCoverage,
+            this.discardExecutable,
+            this.discardNonMagik);
         return bundleCoverageConverter.convert();
     }
 

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/CoberturaXmlReportGenerator.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/CoberturaXmlReportGenerator.java
@@ -31,6 +31,7 @@ public class CoberturaXmlReportGenerator extends BaseReportGenerator {
      * @param executionDataFile File to {@literal jacoco.exec}.
      * @param outputFile File to report file (XML).
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      * @param bundleName Name of the bundle.
      */
     public CoberturaXmlReportGenerator(
@@ -39,8 +40,9 @@ public class CoberturaXmlReportGenerator extends BaseReportGenerator {
             final File executionDataFile,
             final File outputFile,
             final boolean discardExecutable,
+            final boolean discardNonMagik,
             final String bundleName) {
-        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, bundleName);
+        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, discardNonMagik, bundleName);
     }
 
     @Override

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/HtmlReportGenerator.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/HtmlReportGenerator.java
@@ -32,6 +32,7 @@ public final class HtmlReportGenerator extends BaseReportGenerator {
      * @param executionDataFile File to {@literal jacoco.exec}.
      * @param reportDirectory File to report directory (HTML).
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      * @param bundleName Name of the bundle.
      */
     public HtmlReportGenerator(
@@ -40,8 +41,16 @@ public final class HtmlReportGenerator extends BaseReportGenerator {
             final File executionDataFile,
             final File reportDirectory,
             final boolean discardExecutable,
+            final boolean discardNonMagik,
             final String bundleName) {
-        super(productPaths, sourcePaths, executionDataFile, reportDirectory, discardExecutable, bundleName);
+        super(
+            productPaths,
+            sourcePaths,
+            executionDataFile,
+            reportDirectory,
+            discardExecutable,
+            discardNonMagik,
+            bundleName);
     }
 
     @Override

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/JacocoXmlReportGenerator.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/JacocoXmlReportGenerator.java
@@ -32,6 +32,7 @@ public class JacocoXmlReportGenerator extends BaseReportGenerator {
      * @param executionDataFile File to {@literal jacoco.exec}.
      * @param outputFile File to report file (XML).
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      * @param bundleName Name of the bundle.
      */
     public JacocoXmlReportGenerator(
@@ -40,8 +41,9 @@ public class JacocoXmlReportGenerator extends BaseReportGenerator {
             final File executionDataFile,
             final File outputFile,
             final boolean discardExecutable,
+            final boolean discardNonMagik,
             final String bundleName) {
-        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, bundleName);
+        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, discardNonMagik, bundleName);
     }
 
     @Override

--- a/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/SonarXmlReportGenerator.java
+++ b/src/main/java/nl/ramsolutions/sw/magik/jacoco/generators/SonarXmlReportGenerator.java
@@ -32,6 +32,7 @@ public class SonarXmlReportGenerator extends BaseReportGenerator {
      * @param executionDataFile File to {@literal jacoco.exec}.
      * @param outputFile File to report file (XML).
      * @param discardExecutable Discard executable.
+     * @param discardNonMagik Discard non-Magik code.
      * @param bundleName Name of the bundle.
      */
     public SonarXmlReportGenerator(
@@ -40,8 +41,9 @@ public class SonarXmlReportGenerator extends BaseReportGenerator {
             final File executionDataFile,
             final File outputFile,
             final boolean discardExecutable,
+            final boolean discardNonMagik,
             final String bundleName) {
-        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, bundleName);
+        super(productPaths, sourcePaths, executionDataFile, outputFile, discardExecutable, discardNonMagik, bundleName);
     }
 
     @Override

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/conversion/MagikBundleCoverageConverterTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/conversion/MagikBundleCoverageConverterTest.java
@@ -54,7 +54,7 @@ class MagikBundleCoverageConverterTest {
         final Sw5LibAnalyzer libAnalyzer = TestData.getLibAnalyzer();
         final IBundleCoverage bundleCoverageOrig = TestData.getBundleCoverage();
         final MagikBundleCoverageConverter converter =
-            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, false);
+            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, false, false);
 
         final IBundleCoverage bundleCoverage = converter.convert();
 
@@ -77,7 +77,7 @@ class MagikBundleCoverageConverterTest {
         final Sw5LibAnalyzer libAnalyzer = TestData.getLibAnalyzer();
         final IBundleCoverage bundleCoverageOrig = TestData.getBundleCoverage();
         final MagikBundleCoverageConverter converter =
-            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, true);
+            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, true, true);
 
         final IPackageCoverage packageCoverageOrig0 = List.copyOf(bundleCoverageOrig.getPackages()).get(0);
         assertThat(packageCoverageOrig0.getClasses()).hasSize(5);  // 4 classes.

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/conversion/MethodCoverageMergerTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/conversion/MethodCoverageMergerTest.java
@@ -23,7 +23,7 @@ class MethodCoverageMergerTest {
         final Sw5LibAnalyzer libAnalyzer = TestData.getLibAnalyzer();
         final IBundleCoverage bundleCoverageOrig = TestData.getBundleCoverage();
         final MagikBundleCoverageConverter converter =
-            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, false);
+            new MagikBundleCoverageConverter(libAnalyzer, bundleCoverageOrig, false, false);
 
         final IBundleCoverage bundleCoverage = converter.convert();
 

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/CoberturaXmlReportGeneratorTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/CoberturaXmlReportGeneratorTest.java
@@ -21,6 +21,7 @@ class CoberturaXmlReportGeneratorTest {
         final File executionDataFile = TestData.JACOCO_EXEC_FILE;
         final File outputFile = Files.createTempFile("cobertura", ".xml").toFile();
         final boolean discardExecutable = true;
+        final boolean discardNonMagik = true;
         final String bundleName = "TestCobertura";
         final CoberturaXmlReportGenerator coberturaXmlReportGenerator = new CoberturaXmlReportGenerator(
             productPaths,
@@ -28,6 +29,7 @@ class CoberturaXmlReportGeneratorTest {
             executionDataFile,
             outputFile,
             discardExecutable,
+            discardNonMagik,
             bundleName);
         coberturaXmlReportGenerator.run();
 

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/HtmlReportGeneratorTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/HtmlReportGeneratorTest.java
@@ -21,6 +21,7 @@ class HtmlReportGeneratorTest {
         final File executionDataFile = TestData.JACOCO_EXEC_FILE;
         final File outputDir = Files.createTempDirectory("html").toFile();
         final boolean discardExecutable = true;
+        final boolean discardNonMagik = true;
         final String bundleName = "TestHtml";
         final HtmlReportGenerator htmlReportGenerator = new HtmlReportGenerator(
             productPaths,
@@ -28,6 +29,7 @@ class HtmlReportGeneratorTest {
             executionDataFile,
             outputDir,
             discardExecutable,
+            discardNonMagik,
             bundleName);
         htmlReportGenerator.run();
 

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/JacocoXmlReportGeneratorTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/JacocoXmlReportGeneratorTest.java
@@ -21,6 +21,7 @@ class JacocoXmlReportGeneratorTest {
         final File executionDataFile = TestData.JACOCO_EXEC_FILE;
         final File outputFile = Files.createTempFile("jacoco", ".xml").toFile();
         final boolean discardExecutable = true;
+        final boolean discardNonMagik = true;
         final String bundleName = "TestJacoco";
         final JacocoXmlReportGenerator jacocoXmlReportGenerator = new JacocoXmlReportGenerator(
             productPaths,
@@ -28,6 +29,7 @@ class JacocoXmlReportGeneratorTest {
             executionDataFile,
             outputFile,
             discardExecutable,
+            discardNonMagik,
             bundleName);
         jacocoXmlReportGenerator.run();
 

--- a/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/SonarXmlReportGeneratorTest.java
+++ b/src/test/java/nl/ramsolutions/sw/magik/jacoco/generators/SonarXmlReportGeneratorTest.java
@@ -21,6 +21,7 @@ class SonarXmlReportGeneratorTest {
         final File executionDataFile = TestData.JACOCO_EXEC_FILE;
         final File outputFile = Files.createTempFile("sonar", ".xml").toFile();
         final boolean discardExecutable = true;
+        final boolean discardNonMagik = true;
         final String bundleName = "TestSonar";
         final SonarXmlReportGenerator sonarXmlReportGenerator = new SonarXmlReportGenerator(
             productPaths,
@@ -28,6 +29,7 @@ class SonarXmlReportGeneratorTest {
             executionDataFile,
             outputFile,
             discardExecutable,
+            discardNonMagik,
             bundleName);
         sonarXmlReportGenerator.run();
 


### PR DESCRIPTION
Add `--discard-non-magik` option to filter coverage on non-Magik sources.

Fixes #3.